### PR TITLE
Support access to the markdown converter within macros.

### DIFF
--- a/ssg.tcl
+++ b/ssg.tcl
@@ -97,6 +97,13 @@ namespace eval tclssg {
             }
         }
 
+        proc inline-markdown-to-html {text} {
+            set html [markdown-to-html $text]
+            # strip paragraph wrapping, we assume to be in an inline context.
+            regexp {<p>(.*)</p>} $html -> html
+            return $html
+        }
+
         # Make HTML out of rawContent (remove frontmatter, if any; expand macros
         # if expandMacrosInPages is enabled in websiteConfig; convert Markdown
         # to HTML).
@@ -172,6 +179,8 @@ namespace eval tclssg {
                     ::tclssg::utils::slugify            slugify
                     ::tclssg::utils::choose-dir         choose-dir
                     puts                                puts
+                    ::tclssg::templating::inline-markdown-to-html
+                                                        markdown-to-html
                     ::tclssg::templating::interpreter::with-cache
                                                         with-cache-for-filename
                     ::tclssg::pages::get-setting        get-page-setting


### PR DESCRIPTION
Usecase:
- Markdown does not support markdown within HTML blocks.
- When a macro has to generate HTML directly access to the
  converter allows it to accept MD as arguments and
  convert it to HTML itself before placing it into its output.

Tricky part:
- We have to remove the paragraph-wrapping done by the converter
  to not mess up the structure of the HTML. Within HTML the MD
  is essentially inlined, and not a block element.