### PR TITLE
Breaking: new website setting prettyUrls.

### DIFF
--- a/lib/tclssg/command/command.tcl
+++ b/lib/tclssg/command/command.tcl
@@ -49,9 +49,16 @@ namespace eval ::tclssg::command {
     }
 
     proc clean {inputDir outputDir {debugDir {}} {options {}}} {
+        # Do not use -force to avoid deleting read-only files.
         foreach file [::fileutil::find $outputDir {file isfile}] {
             puts "deleting $file"
             file delete $file
+        }
+        # A hack to remove nested subdirectories first.
+        foreach directory [lsort -decr [::fileutil::find \
+                $outputDir {file isdirectory}]] {
+            puts "removing empty directory $directory"
+            file delete $directory
         }
     }
 

--- a/lib/tclssg/pages/pages.tcl
+++ b/lib/tclssg/pages/pages.tcl
@@ -10,6 +10,8 @@ namespace eval ::tclssg::pages {
     namespace export *
     namespace ensemble create
 
+    variable outputFileCallback
+
     # Create tables necessary for various procs called by Tclssg's build
     # command.
     #
@@ -175,6 +177,28 @@ namespace eval ::tclssg::pages {
         } else {
             return $default
         }
+    }
+    proc get-output-file {id} {
+        tclssg-db eval {
+            SELECT
+                outputFile as outputFileStored,
+                inputFile
+            FROM pages WHERE id = $id;
+        } arr {}
+        if {$arr(outputFileStored) eq ""} {
+            if {$arr(inputFile) eq ""} {
+                set result ""
+            } else {
+                variable outputFileCallback
+                set result [$outputFileCallback $arr(inputFile)]
+                # Cache outputFile value.
+                set-data $id outputFile $result
+            }
+        } else {
+            # Retrieve stored value for outputFile.
+            set result $arr(outputFileStored)
+        }
+        return $result
     }
     # Returns the list of ids of all pages sorted by their sortingDate, if
     # any.

--- a/lib/tclssg/pages/pages.tcl
+++ b/lib/tclssg/pages/pages.tcl
@@ -163,6 +163,22 @@ namespace eval ::tclssg::pages {
             tclssg-db eval {
                 DELETE FROM tagPages WHERE id = $id;
             }
+            # Remove $id from articleToAppend. This part of page deletion could
+            # be simplified through normalization of the DB but storing a list
+            # is more convenient everywhere.
+            set collections [tclssg-db eval {
+                SELECT id, articlesToAppend FROM pages
+                WHERE instr(articlesToAppend, $id)
+            }]
+            foreach {topPageId articlesToAppend} $collections {
+                set articlesToAppendUpdated \
+                        [lsearch -all -inline -not -exact \
+                                $articlesToAppend $id]
+                tclssg-db eval {
+                    UPDATE pages SET articlesToAppend=$articlesToAppendUpdated
+                    WHERE id = $topPageId;
+                }
+            }
         }
     }
     proc set-data {id field value} {

--- a/lib/tclssg/pages/pages.tcl
+++ b/lib/tclssg/pages/pages.tcl
@@ -11,6 +11,7 @@ namespace eval ::tclssg::pages {
     namespace ensemble create
 
     variable outputFileCallback
+    variable rssFileCallback
 
     # Create tables necessary for various procs called by Tclssg's build
     # command.
@@ -155,6 +156,12 @@ namespace eval ::tclssg::pages {
             }
             tclssg-db eval {
                 DELETE FROM settings WHERE id = $id;
+            }
+            tclssg-db eval {
+                DELETE FROM tags WHERE id = $id;
+            }
+            tclssg-db eval {
+                DELETE FROM tagPages WHERE id = $id;
             }
         }
     }

--- a/lib/tclssg/pages/pages.tcl
+++ b/lib/tclssg/pages/pages.tcl
@@ -97,7 +97,7 @@ namespace eval ::tclssg::pages {
         }
         return [tclssg-db last_insert_rowid]
     }
-    # Make a copy of page $id in table pages return the id of the copy.
+    # Make a copy of page $id in table pages and return the id of the copy.
     proc copy {id copySettings} {
         tclssg-db eval {
             INSERT INTO pages(

--- a/lib/tclssg/templating/cache/cache.tcl
+++ b/lib/tclssg/templating/cache/cache.tcl
@@ -17,12 +17,12 @@ namespace eval ::tclssg::templating::cache {
     # directory (because relative link paths for the sidebar and the tag
     # cloud are the same for such files, and that is what the cache is
     # used for).
-    proc fresh? {newFile} {
+    proc fresh? {filename} {
         variable cachedFile
         variable data
 
-        set result [expr {
-            [file dirname $cachedFile] eq [file dirname $newFile]
+        ::set result [expr {
+            [file dirname $cachedFile] eq [file dirname $filename]
         }]
         return $result
     }
@@ -34,42 +34,33 @@ namespace eval ::tclssg::templating::cache {
 
     # Update cache item $key. If the rest of the cache is no longer
     # fresh discard it.
-    proc update-key {newFile key varName} {
+    proc set {filename key value} {
         variable cachedFile
         variable data
 
-        upvar 1 $varName var
-
-        if {![fresh? $newFile]} {
-            set data {}
-            set cachedFile $newFile
+        if {![fresh? $filename]} {
+            ::set data {}
+            ::set cachedFile $filename
         }
-        dict set data $key $var
+        dict set data $key $value
     }
 
-    # Use varName as the key in update-key.
-    proc update {newFile varName} {
-        upvar 1 $varName localVar
-        update-key $newFile $varName localVar
-    }
-
-    # If fresh for newFile retrieve the cached value under key and put
-    # it in variable varName.
-    proc retrieve-key! {newFile key varName} {
-        upvar 1 $varName var
-
+    proc get {filename key} {
+        variable cachedFile
         variable data
 
-        if {![fresh? $newFile] || ![dict exists $data $key]} {
-            return 0
+        if {[fresh? $filename]} {
+            return [dict get $data $key]
+        } else {
+            error "trying to retrieve stale cache"
         }
-        set var [dict get $data $key]
-        return 1
     }
 
-    # Use varName as key for retrieve-key!.
-    proc retrieve! {newFile varName} {
-        upvar 1 $varName localVar
-        retrieve-key! $newFile $varName localVar
+    proc exists {filename key} {
+        variable data
+
+        return [expr {
+            [fresh? $filename] && [dict exists $data $key]
+        }]
     }
  } ;# namespace cache

--- a/lib/tclssg/templating/interpreter/interpreter.tcl
+++ b/lib/tclssg/templating/interpreter/interpreter.tcl
@@ -60,6 +60,10 @@ namespace eval ::tclssg::templating::interpreter {
             interp alias templateInterp $alias {} {*}$command
         }
 
+        interp alias templateInterp get-rss-file {} apply {{callback id} {
+            return [$callback [tclssg pages get-data $id inputFile]]
+        }} $::tclssg::pages::rssFileCallback
+
         # Expose built-ins.
         foreach builtIn {source} {
             interp expose templateInterp $builtIn

--- a/lib/tclssg/templating/interpreter/interpreter.tcl
+++ b/lib/tclssg/templating/interpreter/interpreter.tcl
@@ -109,14 +109,14 @@ namespace eval ::tclssg::templating::interpreter {
     }
 
     # Run $script and cache the result. Return that result immediately
-    # if the script has already been run for $outputFile.
-    proc with-cache {outputFile script} {
-        set result {}
-        if {![[namespace parent]::cache::retrieve-key! \
-                    $outputFile $script result]} {
+    # if the script has already been run for $filename.
+    proc with-cache {filename script} {
+        set ns [namespace parent]::cache
+        if {[$ns exists $filename $script]} {
+            set result [$ns get $filename $script]
+        } else {
             set result [interp eval templateInterp $script]
-            [namespace parent]::cache::update-key \
-                    $outputFile $script result
+            $ns set $filename $script $result
         }
         return $result
     }

--- a/lib/tclssg/templating/interpreter/interpreter.tcl
+++ b/lib/tclssg/templating/interpreter/interpreter.tcl
@@ -111,12 +111,12 @@ namespace eval ::tclssg::templating::interpreter {
     # Run $script and cache the result. Return that result immediately
     # if the script has already been run for $filename.
     proc with-cache {filename script} {
-        set ns [namespace parent]::cache
-        if {[$ns exists $filename $script]} {
-            set result [$ns get $filename $script]
+        set cache [namespace parent]::cache
+        if {[$cache exists $filename $script]} {
+            set result [$cache get $filename $script]
         } else {
             set result [interp eval templateInterp $script]
-            $ns set $filename $script $result
+            $cache set $filename $script $result
         }
         return $result
     }

--- a/lib/tclssg/templating/interpreter/interpreter.tcl
+++ b/lib/tclssg/templating/interpreter/interpreter.tcl
@@ -46,6 +46,7 @@ namespace eval ::tclssg::templating::interpreter {
             ::tclssg::pages::get-link           get-page-link
             ::tclssg::pages::get-tags           get-page-tags
             ::tclssg::pages::get-tag-page       get-tag-page
+            ::tclssg::pages::get-output-file    get-output-file
             ::msgcat::mc                        mc
             ::msgcat::mcset                     mcset
             ::msgcat::mclocale                  mclocale

--- a/skeleton/templates/common.tcl
+++ b/skeleton/templates/common.tcl
@@ -52,12 +52,23 @@ proc absolute-link {id} {
         error "using absolute-link requires that url be set in website config"
     }
     set outputDir [get-website-config-setting outputDir ""]
-    return $url[replace-path-root [get-page-data $id outputFile] $outputDir ""]
+    return $url[replace-path-root [get-output-file $id] $outputDir ""]
 }
 
 proc relative-link {id} {
     global currentPageId
-    return [get-page-link $currentPageId $id]
+    global collectionPageId
+    if {[info exists collectionPageId]} {
+        set fromId $collectionPageId
+    } else {
+        set fromId $currentPageId
+    }
+    set link [get-page-link $fromId $id]
+    #if {($link eq "") && ($id ne $fromId)} {
+    #    error "cannot find relative link from [get-page-data \
+    #            $fromId inputFile] to [get-page-data $id inputFile]"
+    #}
+    return $link
 }
 
 proc link-or-nothing {websiteVarName} {
@@ -75,7 +86,7 @@ set blogIndexLink [link-or-nothing blogIndexPageId]
 
 proc with-cache script {
     global currentPageId
-    with-cache-for-filename [get-page-data $currentPageId outputFile] $script
+    with-cache-for-filename [get-output-file $currentPageId] $script
 }
 
 proc blog-post? {} {

--- a/skeleton/templates/common.tcl
+++ b/skeleton/templates/common.tcl
@@ -64,10 +64,7 @@ proc relative-link {id} {
         set fromId $currentPageId
     }
     set link [get-page-link $fromId $id]
-    #if {($link eq "") && ($id ne $fromId)} {
-    #    error "cannot find relative link from [get-page-data \
-    #            $fromId inputFile] to [get-page-data $id inputFile]"
-    #}
+
     return $link
 }
 

--- a/skeleton/templates/common.tcl
+++ b/skeleton/templates/common.tcl
@@ -47,6 +47,7 @@ proc page-setting {page name {default ""}} {
 # Utility procs.
 
 proc absolute-link {id} {
+    global currentPageId
     set url [get-website-config-setting url ""]
     if {$url eq ""} {
         error "using absolute-link requires that url be set in website config"

--- a/skeleton/templates/document.tcl
+++ b/skeleton/templates/document.tcl
@@ -60,19 +60,16 @@ proc format-document-title {} {
 
 proc rss-feed-link {} {
     global currentPageId
+    set outputDir [website-setting outputDir]
     set tagPageTag [setting tagPageTag]
-    if {($tagPageTag ne "") && ([website-setting {rss tagFeeds} 0])} {
+    set url "[ website-setting url ][replace-path-root \
+            [get-rss-file $currentPageId] $outputDir ""]"
+
+    if {(($tagPageTag ne "") && ([website-setting {rss tagFeeds} 0])) ||
+            ($currentPageId eq [website-setting blogIndexPageId])} {
         set rel alternate
-        set pageId [get-tag-page $tagPageTag 0]
-        set url [regsub {.html$} [absolute-link $pageId] .xml]
     } else {
-        if {$currentPageId eq [website-setting blogIndexPageId]} {
-            set rel alternate
-        } else {
-            set rel home
-        }
-        set url "[ website-setting url ][ website-setting \
-                {rss feedFilename} rss.xml ]"
+        set rel home
     }
     return [list $rel $url]
 }

--- a/ssg.tcl
+++ b/ssg.tcl
@@ -193,8 +193,6 @@ namespace eval tclssg {
         # Filter out pages to that set hideFromCollections to 1.
         set pageIds [::struct::list filterfor x $pageIds {
             ($x ne $topPageId) &&
-            ($x ne $blogIndexPageId) &&
-            ($x ne $tagPageId) &&
             ![tclssg pages get-setting $x hideFromCollections 0]
         }]
 

--- a/ssg.tcl
+++ b/ssg.tcl
@@ -373,6 +373,7 @@ namespace eval tclssg {
 
         validate-config $inputDir $contentDir
 
+        set prettyUrls [tclssg pages get-website-config-setting prettyUrls 0]
         # A callback to determine outputFile from inputFile.
         proc ::tclssg::detOutputFile {inputFile} [list \
             apply {{contentDir outputDir prettyUrls} {
@@ -392,8 +393,7 @@ namespace eval tclssg {
             }} \
             $contentDir \
             $outputDir \
-            [tclssg pages get-website-config-setting \
-                    prettyUrls 0]]
+            $prettyUrls]
         set ::tclssg::pages::outputFileCallback ::tclssg::detOutputFile
 
         variable settingSynonyms
@@ -536,7 +536,7 @@ namespace eval tclssg {
 
             # Use the previous list of relative links if the current file is
             # in the same directory as the previous one.
-            if {[templating cache retrieve! $outputFile pageLinks]} {
+            if {[templating cache fresh? $outputFile]} {
                 tclssg pages copy-links \
                         [tclssg pages output-file-to-id \
                                 [templating cache filename]] $id
@@ -555,14 +555,14 @@ namespace eval tclssg {
                 }
                 # Store links to other pages and website root path relative to
                 # the current page
-                set prettyUrls [tclssg pages \
-                        get-website-config-setting prettyUrls 0]
                 foreach {targetId link} $pageLinks {
                     if {$prettyUrls} {
                         set link [regsub {index.html$} $link {}]
                     }
                     tclssg pages add-link $id $targetId $link
                 }
+
+                templating cache set $outputFile pageLinks 1
             }
 
             # Relative path to the root directory of the output.


### PR DESCRIPTION
This introduces the website setting `prettyUrls` that allows you to generate URLs like http://example.com/blog/post-1/ and http://example.com/blog/tags/foo/ instead of http://example.com/blog/post-1.html and http://example.com/blog/tags/foo.html respectively. This is done by not storing `outputFile` values at the start and instead registering a callback for transforming `inputFile` values into `outputFile` values as needed. I consider this a cleaner, better design.

Unfortunately, the current implementation incurs a 2x-3x performance penalty in benchmarks even with caching. Before this branch can be merged the source of the performance regression should be found and eliminated.